### PR TITLE
Identity soln fix

### DIFF
--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -309,6 +309,13 @@ func (s *Watcher) Unwatch(pod *slim_corev1.Pod) error {
 		return nil
 	}
 
+	if s == nil || s.mutex == nil {
+		// "segmentation violation" occours at s.mutex.Lock()
+		// - monitors others crashs in s.mutex.Lock()
+		log.Errorf("spiffe(Unwatch): problem with object Watcher or mutex")
+		return nil
+	}
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 


### PR DESCRIPTION
This commit introduces a temporary solution to avoid coredump inside the
spiffe package, in function Unwatch(). It was not found a way to reproduces
the crash to understand the root causes. Therefore, for now, it was not
possible to create a solid solution.