### PR TITLE
Generating proper Hubble flow records in CEWs

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -986,6 +986,9 @@ func init() {
 	flags.String(option.SpirePrivilegedAPISocketPath, defaults.SpirePrivilegedAPISocketPath, "Socket path to contact the Spire agent")
 	option.BindEnv(option.Config.SpirePrivilegedAPISocketPath)
 
+	flags.Bool(option.ExternalWorkload, defaults.ExternalWorkload, "Specifies whether the agent runs in an external workload")
+	option.BindEnv(option.ExternalWorkload)
+
 	viper.BindPFlags(flags)
 }
 

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
@@ -190,7 +191,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 				specialIdentities = append(specialIdentities,
 					identity.IPIdentityPair{
 						IP: ip,
-						ID: identity.ReservedIdentityHost,
+						ID: identity.GetReservedID(labels.IDNameHost),
 					})
 			}
 		}
@@ -219,7 +220,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 				specialIdentities = append(specialIdentities,
 					identity.IPIdentityPair{
 						IP: ip,
-						ID: identity.ReservedIdentityHost,
+						ID: identity.GetReservedID(labels.IDNameHost),
 					})
 			}
 		}
@@ -239,7 +240,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 
 	for _, ipIDPair := range specialIdentities {
 		hostKey := node.GetIPsecKeyIdentity()
-		isHost := ipIDPair.ID == identity.ReservedIdentityHost
+		isHost := ipIDPair.ID == identity.GetReservedID(labels.IDNameHost)
 		if isHost {
 			added, err := lxcmap.SyncHostEntry(ipIDPair.IP)
 			if err != nil {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -238,6 +238,7 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 		return err
 	}
 
+	var k8sMeta *ipcache.K8sMetadata
 	for _, ipIDPair := range specialIdentities {
 		hostKey := node.GetIPsecKeyIdentity()
 		isHost := ipIDPair.ID == identity.GetReservedID(labels.IDNameHost)
@@ -249,13 +250,20 @@ func (d *Daemon) syncEndpointsAndHostIPs() error {
 			if added {
 				log.WithField(logfields.IPAddr, ipIDPair.IP).Debugf("Added local ip to endpoint map")
 			}
+
+			if option.Config.ExternalWorkload {
+				// Host IP address might have k8s metadata associated with it
+				// when the agent is running in an External Workload.
+				// Existing metadata should not be overwritten by the following Upsert() call.
+				k8sMeta = ipcache.IPIdentityCache.GetK8sMetadata(ipIDPair.IP.String())
+			}
 		}
 
 		delete(existingEndpoints, ipIDPair.IP.String())
 
 		// Upsert will not propagate (reserved:foo->ID) mappings across the cluster,
 		// and we specifically don't want to do so.
-		ipcache.IPIdentityCache.Upsert(ipIDPair.PrefixString(), nil, hostKey, nil, ipcache.Identity{
+		ipcache.IPIdentityCache.Upsert(ipIDPair.PrefixString(), nil, hostKey, k8sMeta, ipcache.Identity{
 			ID:     ipIDPair.ID,
 			Source: source.Local,
 		})

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -443,4 +443,7 @@ const (
 
 	// SpirePrivilegedAPISocketPath is the path of the Unix domain socket used to contact the Spire agent.
 	SpirePrivilegedAPISocketPath = "/run/spire/sockets-admin/admin.sock"
+
+	// ExternalWorload specifies whether the agent runs in an external workload
+	ExternalWorkload = false
 )

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // Identity is the representation of the security context for a particular set of
@@ -247,8 +248,9 @@ func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
 			// the new list of labels. This is to ensure the local node retains
 			// this identity regardless of label changes.
 			id := GetReservedID(lbl.Key)
-			if id == ReservedIdentityHost {
-				identity := NewIdentity(ReservedIdentityHost, lbls)
+
+			if id == ReservedIdentityHost || (option.Config.ExternalWorkload && (id == GetLocalNodeID())) {
+				identity := NewIdentity(id, lbls)
 				// Pre-calculate the SHA256 hash.
 				identity.GetLabelsSHA256()
 				return identity

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/model"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 
@@ -115,7 +116,7 @@ func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 	}
 	// The host endpoint will always retain its reserved ID, but its labels may
 	// change so we need to update its identity.
-	if old != nil && new != nil && old.ID == new.ID && new.ID != identity.ReservedIdentityHost {
+	if old != nil && new != nil && old.ID == new.ID && new.ID != identity.GetReservedID(labels.IDNameHost) {
 		return
 	}
 

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -445,10 +445,10 @@ func GetLocalNodeID() NumericIdentity {
 
 // SetLocalNodeID sets the local node id.
 // Note that currently changes to the local node id only take effect during agent bootstrap
-func SetLocalNodeID(nodeid uint32) {
+func SetLocalNodeID(nodeid NumericIdentity) {
 	localNodeIdentity.Lock()
 	defer localNodeIdentity.Unlock()
-	localNodeIdentity.identity = NumericIdentity(nodeid)
+	localNodeIdentity.identity = nodeid
 }
 
 func GetReservedID(name string) NumericIdentity {
@@ -489,4 +489,22 @@ func IterateReservedIdentities(f func(key string, value NumericIdentity)) {
 // HasLocalScope returns true if the identity has a local scope
 func (id NumericIdentity) HasLocalScope() bool {
 	return (id & LocalIdentityFlag) != 0
+}
+
+// SetReservedHostIdentity replaces the value of host identity(1)
+// with `nid` and adds labels specified by `lbls` to the host identity.
+// Called by JoinCluster() if option.Config.ExternalWorkload is set to true.
+func SetReservedHostIdentity(nid NumericIdentity, lbls map[string]string) {
+	// Delete default/exisiting ReservedHost identity
+	delete(reservedIdentityNames, GetReservedID(labels.IDNameHost))
+	delete(ReservedIdentityCache, GetReservedID(labels.IDNameHost))
+
+	// Update new host identity
+	reservedIdentities[labels.IDNameHost] = nid
+	reservedIdentityNames[nid] = labels.IDNameHost
+
+	newlables := labels.Map2Labels(lbls, labels.LabelSourceK8s)
+	newlables.MergeLabels(labels.LabelHost)
+	newHostIdentity := NewIdentity(nid, newlables)
+	ReservedIdentityCache[nid] = newHostIdentity
 }

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -270,6 +271,13 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8s
 	cachedIdentity, found := ipc.ipToIdentityCache[ip]
 	if found {
 		if !source.AllowOverwrite(cachedIdentity.Source, newIdentity.Source) {
+			// Host IP address might have k8s metadata associated with it
+			// when the agent is running in an External Workload.
+			if option.Config.ExternalWorkload && (cachedIdentity.ID == identity.GetReservedID(labels.IDNameHost)) {
+				callbackListeners = false
+				goto k8sMetadataUpdate
+			}
+
 			return false, NewErrOverwrite(cachedIdentity.Source, newIdentity.Source)
 		}
 
@@ -349,6 +357,7 @@ func (ipc *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8s
 		ipc.ipToHostIPCache[ip] = IPKeyPair{IP: hostIP, Key: hostKey}
 	}
 
+k8sMetadataUpdate:
 	if !metaEqual {
 		if k8sMeta == nil {
 			delete(ipc.ipToK8sMetadata, ip)

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node/addressing"
@@ -341,7 +342,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 	dpUpdate := true
 	nodeIP := n.GetNodeIP(false)
 
-	remoteHostIdentity := identity.ReservedIdentityHost
+	remoteHostIdentity := identity.GetReservedID(labels.IDNameHost)
 	if m.conf.RemoteNodeIdentitiesEnabled() {
 		nid := identity.NumericIdentity(n.NodeIdentity)
 		if nid != identity.IdentityUnknown {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -170,7 +170,12 @@ func (n *NodeDiscovery) JoinCluster(nodeName string) {
 	if resp.IPv6AllocCIDR != nil {
 		node.SetIPv6NodeRange(resp.IPv6AllocCIDR)
 	}
-	identity.SetLocalNodeID(resp.NodeIdentity)
+
+	nid := identity.NumericIdentity(resp.NodeIdentity)
+	identity.SetLocalNodeID(nid)
+	if (nid != identity.IdentityUnknown) && option.Config.ExternalWorkload {
+		identity.SetReservedHostIdentity(nid, resp.Labels)
+	}
 }
 
 // start configures the local node and starts node discovery. This is called on

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -957,6 +957,9 @@ const (
 	// SpirePrivilegedAPISocketPath is the name of the option that defines the
 	// path of the Unix domain socket used to contact the Spire agent.
 	SpirePrivilegedAPISocketPath = "spire-privileged-api-socket-path"
+
+	// ExternalWorkload specifies whether the agent runs in a external worload.
+	ExternalWorkload = "external-workload"
 )
 
 // Default string arguments
@@ -1963,6 +1966,9 @@ type DaemonConfig struct {
 	// SpirePrivilegedAPISocketPath is the path of the Unix domain socket used
 	// to contact the Spire agent.
 	SpirePrivilegedAPISocketPath string
+
+	// ExternalWorload specifies whether the agent runs in an external workload
+	ExternalWorkload bool
 }
 
 var (
@@ -2012,6 +2018,7 @@ var (
 		APIRateLimit:                     make(map[string]string),
 
 		ExternalClusterIP: defaults.ExternalClusterIP,
+		ExternalWorkload:  defaults.ExternalWorkload,
 	}
 )
 
@@ -2746,6 +2753,7 @@ func (c *DaemonConfig) Populate() {
 	c.EndpointGCInterval = viper.GetDuration(EndpointGCInterval)
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
+	c.ExternalWorkload = viper.GetBool(ExternalWorkload)
 }
 
 func (c *DaemonConfig) populateDevices() {

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -21,6 +21,7 @@ import (
 
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -209,6 +210,6 @@ func (cip *cachedSelectorPolicy) Consume(owner PolicyOwner, repo *Repository) *E
 	// TODO: This currently computes the EndpointPolicy from SelectorPolicy
 	// on-demand, however in future the cip is intended to cache the
 	// EndpointPolicy for this Identity and emit datapath deltas instead.
-	isHost := cip.identity.ID == identityPkg.ReservedIdentityHost
+	isHost := cip.identity.ID == identityPkg.GetReservedID(labels.IDNameHost)
 	return cip.getPolicy().DistillPolicy(owner, isHost, repo)
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -727,7 +727,7 @@ func createL4IngressFilter(policyCtx PolicyContext, fromEndpoints api.EndpointSe
 	// TODO: this breaks ingress traffic from same host
 	//	if !pr.Rules.IsEmpty() && len(hostWildcardL7) > 0 {
 	//		for cs := range filter.L7RulesPerSelector {
-	//			if cs.Selects(identity.ReservedIdentityHost) {
+	//			if cs.Selects(identity.GetReservedID(labels.IDNameHost)) {
 	//				for _, name := range hostWildcardL7 {
 	//					selector := api.ReservedEndpointSelectors[name]
 	//					filter.cacheIdentitySelector(selector, policyCtx.GetSelectorCache(), policyCtx.IsDeny())

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -30,7 +30,7 @@ import (
 var (
 	// localHostKey represents an ingress L3 allow from the local host.
 	localHostKey = Key{
-		Identity:         identity.ReservedIdentityHost.Uint32(),
+		Identity:         identity.GetReservedID(labels.IDNameHost).Uint32(),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 	// localRemoteNodeKey represents an ingress L3 allow from remote nodes.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -434,13 +434,17 @@ func (p *Repository) Add(r api.Rule, localRuleConsumers []Endpoint) (uint64, map
 
 func (p *Repository) UpdateAuditModeL7Rules(rule *api.Rule) {
 	//MTODO: Need to update the audit mode in L7 rules
-	for _, toPorts := range rule.Ingress {
-		for _, l7Rules := range toPorts.ToPorts {
+	for _, ingressRule := range rule.Ingress {
+		for _, portRule := range ingressRule.ToPorts {
+			l7Rules := portRule.Rules
+			if l7Rules == nil {
+				continue
+			}
 			switch {
-			case len(l7Rules.Rules.HTTP) > 0:
-				for index := range l7Rules.Rules.HTTP {
-					l7Rules.Rules.HTTP[index].AuditMode = rule.AuditMode
-					l7Rules.Rules.HTTP[index].RuleID = p.GetRuleIDbyPolicyName(rule.Labels)
+			case len(l7Rules.HTTP) > 0:
+				for index := range l7Rules.HTTP {
+					l7Rules.HTTP[index].AuditMode = rule.AuditMode
+					l7Rules.HTTP[index].RuleID = p.GetRuleIDbyPolicyName(rule.Labels)
 				}
 			}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -650,7 +650,7 @@ func (p *Repository) getMatchingRules(securityIdentity *identity.Identity) (
 
 	matchingRules = []*rule{}
 	for _, r := range p.rules {
-		isNode := securityIdentity.ID == identity.ReservedIdentityHost
+		isNode := securityIdentity.ID == identity.GetReservedID(labels.IDNameHost)
 		selectsNode := r.NodeSelector.LabelSelector != nil
 		if selectsNode != isNode {
 			continue

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -620,7 +620,7 @@ func (r *rule) matches(securityIdentity *identity.Identity) bool {
 	if ruleMatches, cached := r.metadata.IdentitySelected[securityIdentity.ID]; cached {
 		return ruleMatches
 	}
-	isNode := securityIdentity.ID == identity.ReservedIdentityHost
+	isNode := securityIdentity.ID == identity.GetReservedID(labels.IDNameHost)
 	if (r.NodeSelector.LabelSelector != nil) != isNode {
 		r.metadata.IdentitySelected[securityIdentity.ID] = false
 		return ruleMatches

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -122,7 +123,7 @@ func (lr *LogRecord) fillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP) {
 		// first we try to resolve and check if the IP is
 		// same as Host
 		if node.IsHostIPv4(ip) {
-			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.ReservedIdentityHost, info)
+			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.GetReservedID(labels.IDNameHost), info)
 		} else if !lr.endpointInfoRegistry.FillEndpointIdentityByIP(ip, info) {
 			// If we are unable to resolve the HostIP as well
 			// as the cluster IP we mark this as a 'world' identity.
@@ -132,7 +133,7 @@ func (lr *LogRecord) fillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP) {
 		info.IPv6 = ip.String()
 
 		if node.IsHostIPv6(ip) {
-			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.ReservedIdentityHost, info)
+			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.GetReservedID(labels.IDNameHost), info)
 		} else if !lr.endpointInfoRegistry.FillEndpointIdentityByIP(ip, info) {
 			lr.endpointInfoRegistry.FillEndpointIdentityByID(identity.ReservedIdentityWorld, info)
 		}


### PR DESCRIPTION
This PR tries to fix this issue by replacing the host ID(1) with the value of node ID (which the agent gets from clustermesh-apiserver) in appropriate userspace maps.

**Commits Summary**

- Added a new runtime option in the agent --external-workload to explicitly specify that the agent is running in an external workload environment.
- In CEW, replace the host ID (1) with local node ID and add node labels to the host identity.
- Replaced the usage of const ReservedIdentityHost in the code with GetReservedID(labels.IDNameHost) method wherever necessary.
- Updated the k8s metadata of CEW in the IPIdentityCache.ipToK8sMetadata map.

Please look into individual commit messages for a detailed information.