### PR TITLE
Cilium external workload changes

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -744,6 +744,9 @@ func NewDaemon(ctx context.Context, cancel context.CancelFunc, epMgr *endpointma
 
 		// Start services watcher
 		serviceStore.JoinClusterServices(&d.k8sWatcher.K8sSvcCache, option.Config)
+
+		// Start policy watcher
+		policy.InitPolicyWatcher(&d)
 	}
 
 	// Start IPAM

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver-clusterrole.yaml
@@ -39,6 +39,7 @@ rules:
   - ciliumidentities/status
   - ciliumendpoints
   - ciliumendpoints/status
+  - ciliumclusterwidenetworkpolicies
   verbs:
   - '*'
 {{- end }}

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -46,7 +45,6 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 
 	"github.com/sirupsen/logrus"
@@ -129,12 +127,6 @@ type nodeDiscoverManager interface {
 	ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration
 }
 
-type policyManager interface {
-	TriggerPolicyUpdates(force bool, reason string)
-	PolicyAdd(rules api.Rules, opts *policy.AddOptions) (newRev uint64, err error)
-	PolicyDelete(labels labels.LabelArray) (newRev uint64, err error)
-}
-
 type policyRepository interface {
 	TranslateRules(translator policy.Translator) (*policy.TranslationResult, error)
 }
@@ -187,7 +179,7 @@ type K8sWatcher struct {
 	endpointManager endpointManager
 
 	nodeDiscoverManager   nodeDiscoverManager
-	policyManager         policyManager
+	policyManager         policy.PolicyManager
 	policyRepository      policyRepository
 	svcManager            svcManager
 	redirectPolicyManager redirectPolicyManager
@@ -218,7 +210,7 @@ type K8sWatcher struct {
 func NewK8sWatcher(
 	endpointManager endpointManager,
 	nodeDiscoverManager nodeDiscoverManager,
-	policyManager policyManager,
+	policyManager policy.PolicyManager,
 	policyRepository policyRepository,
 	svcManager svcManager,
 	datapath datapath.Datapath,

--- a/pkg/node/types/nodename.go
+++ b/pkg/node/types/nodename.go
@@ -25,6 +25,8 @@ import (
 
 var (
 	nodeName = "localhost"
+
+	EnvCewName = "CEW_NAME"
 )
 
 // SetName sets the name of the local node. This will overwrite the value that
@@ -57,11 +59,17 @@ func GetAbsoluteNodeName() string {
 }
 
 func init() {
-	// Give priority to the environment variable available in the Cilium agent
+	// Give priority to the environment variables available in the Cilium agent
 	if name := os.Getenv(k8sConsts.EnvNodeNameSpec); name != "" {
 		nodeName = name
 		return
 	}
+
+	if name := os.Getenv(EnvCewName); name != "" {
+		nodeName = name
+		return
+	}
+
 	if h, err := os.Hostname(); err != nil {
 		log.WithError(err).Warn("Unable to retrieve local hostname")
 	} else {

--- a/pkg/policy/kvstore.go
+++ b/pkg/policy/kvstore.go
@@ -1,12 +1,118 @@
 package policy
 
 import (
+	"context"
+	"encoding/json"
 	"path"
+	"strings"
+	"time"
 
+	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/sirupsen/logrus"
 )
+
+type policyWatcher struct {
+	backend       kvstore.BackendOperations
+	policyManager PolicyManager
+}
 
 var (
 	// CCNPPath is the path to where CCNPs are stored in the key-value store.
 	CCNPPath = path.Join(kvstore.BaseKeyPrefix, "state", "policies", "v1", "ccnp")
 )
+
+func newPolicyWatcher(backend kvstore.BackendOperations, policyManger PolicyManager) *policyWatcher {
+	return &policyWatcher{
+		backend,
+		policyManger,
+	}
+}
+
+func InitPolicyWatcher(pm PolicyManager) {
+	watcher := newPolicyWatcher(kvstore.Client(), pm)
+	go func() {
+		log.Info("Starting policy watcher")
+		watcher.CCNPWatch(context.TODO())
+	}()
+}
+
+func (w *policyWatcher) CCNPWatch(ctx context.Context) {
+	var scopedLog *logrus.Entry
+	var policyName string
+	var policyLabels labels.LabelArray
+
+restart:
+	watcher := kvstore.Client().ListAndWatch(ctx, "CCNPWatcher", CCNPPath, 512)
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				log.Debugf("%s closed, restarting watch", watcher.String())
+				time.Sleep(500 * time.Millisecond)
+				goto restart
+			}
+
+			if option.Config.Debug {
+				scopedLog = log.WithFields(logrus.Fields{"kvstore-event": event.Typ.String(), "key": event.Key})
+				scopedLog.Debug("Received event")
+			}
+
+			if event.Typ != kvstore.EventTypeListDone {
+				policyName = strings.TrimPrefix(event.Key, (CCNPPath + "/"))
+				policyLabels = labels.LabelArray{
+					labels.NewLabel("policy.name", policyName, labels.LabelSourceCiliumGenerated),
+					labels.NewLabel("policy.derived-from", k8sUtils.ResourceTypeCiliumClusterwideNetworkPolicy, labels.LabelSourceCiliumGenerated),
+				}
+			}
+
+			switch event.Typ {
+			case kvstore.EventTypeCreate, kvstore.EventTypeModify:
+				var ccnp api.Rule
+				err := json.Unmarshal(event.Value, &ccnp)
+				if err != nil {
+					scopedLog.WithError(err).Error("Error unmarshaling data from kvstore")
+					continue
+				}
+
+				if err := ccnp.Sanitize(); err != nil {
+					metrics.PolicyImportErrorsTotal.Inc()
+					scopedLog.WithError(err).Error("Failed to add CCNP from kvstore")
+					continue
+				}
+
+				ccnp.Labels = append(ccnp.Labels, policyLabels...)
+
+				_, err = w.policyManager.PolicyAdd(api.Rules{&ccnp}, &AddOptions{
+					ReplaceWithLabels: policyLabels,
+					Source:            metrics.LabelEventSourceK8s,
+				})
+
+				if err != nil {
+					metrics.PolicyImportErrorsTotal.Inc()
+					scopedLog.WithError(err).Error("Failed to add CCNP from kvstore")
+				} else {
+					scopedLog.Info("Imported CCNP from kvstore")
+				}
+
+			case kvstore.EventTypeDelete:
+				_, err := w.policyManager.PolicyDelete(policyLabels)
+				if err != nil {
+					scopedLog.WithError(err).Error("Failed to delete CCNP")
+				} else {
+					scopedLog.Info("Deleted CCNP")
+				}
+			}
+		case <-ctx.Done():
+			// Stop this policy watcher, we have been signaled to shut down
+			// via context.
+			watcher.Stop()
+			return
+		}
+	}
+}

--- a/pkg/policy/kvstore.go
+++ b/pkg/policy/kvstore.go
@@ -1,0 +1,12 @@
+package policy
+
+import (
+	"path"
+
+	"github.com/cilium/cilium/pkg/kvstore"
+)
+
+var (
+	// CCNPPath is the path to where CCNPs are stored in the key-value store.
+	CCNPPath = path.Join(kvstore.BaseKeyPrefix, "state", "policies", "v1", "ccnp")
+)

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -123,3 +123,9 @@ func (s *SearchContext) WithLogger(log io.Writer) *SearchContext {
 type Translator interface {
 	Translate(*api.Rule, *TranslationResult) error
 }
+
+type PolicyManager interface {
+	TriggerPolicyUpdates(force bool, reason string)
+	PolicyAdd(rules api.Rules, opts *AddOptions) (newRev uint64, err error)
+	PolicyDelete(labels labels.LabelArray) (newRev uint64, err error)
+}


### PR DESCRIPTION
**k8s control plane**
- `clustermesh-apiserver` - fetch CCNPs from CRD and update them in the kv-store.

**k8s and non-k8s control plane**
- `cilium-agent` - fetch CCNPs from the kv-store and update local policy repository.
- Configure workload (VM) name using `CEW_NAME` env variable. Agent will use this value for the node name instead of using the hostname.



