### PR TITLE
hubble: Check for flow type in TCP flag flow filter

### DIFF
--- a/pkg/hubble/filters/tcp.go
+++ b/pkg/hubble/filters/tcp.go
@@ -24,7 +24,11 @@ import (
 
 func filterByTCPFlags(flags []*flowpb.TCPFlags) (FilterFunc, error) {
 	return func(ev *v1.Event) bool {
-		l4tcp := ev.GetFlow().GetL4().GetTCP()
+		flow := ev.GetFlow()
+		if flow == nil || flow.Type != flowpb.FlowType_L3_L4 {
+			return false
+		}
+		l4tcp := flow.GetL4().GetTCP()
 		if l4tcp == nil {
 			return false
 		}

--- a/pkg/hubble/filters/tcp_test.go
+++ b/pkg/hubble/filters/tcp_test.go
@@ -116,7 +116,7 @@ func TestFlowTCPFilter(t *testing.T) {
 	for _, tt := range testflags {
 		argsfilter = []*flowpb.FlowFilter{{TcpFlags: tt.argsf}}
 		argsevent = &v1.Event{Event: &flowpb.Flow{
-			L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{Flags: tt.argsev}}}}}
+			Type: flowpb.FlowType_L3_L4, L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{Flags: tt.argsev}}}}}
 		t.Run(tt.name, func(t *testing.T) {
 			fl, err := BuildFilterList(context.Background(), argsfilter, []OnBuildFilter{&TCPFilter{}})
 			if err != nil {


### PR DESCRIPTION
Cilium agent crashes when an L7/HTTP flow is passed to TCP flag flow
filter (`filterByTCPFlags`). This is because HTTP flows will have
some L4/TCP info such as src/dst port in the flow struct, but will not
contain TCP flags.

Added checks to look for TCP flags in the flow struct only if the flow
is of type `FlowType_L3_L4`

Signed-off-by: Wazir Ahmed <wazir@accuknox.com>