### PR TITLE
Support for L7 Host Policy

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -45,14 +45,6 @@
 #error "Either ENABLE_ARP_PASSTHROUGH or ENABLE_ARP_RESPONDER can be defined"
 #endif
 
-#if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
-static __always_inline bool redirect_to_proxy(int verdict, __u8 dir)
-{
-	return is_defined(ENABLE_HOST_REDIRECT) && verdict > 0 &&
-	       (dir == CT_NEW || dir == CT_ESTABLISHED ||  dir == CT_REOPENED);
-}
-#endif
-
 #ifdef ENABLE_CUSTOM_CALLS
 /* Encode return value and identity into cb buffer. This is used before
  * executing tail calls to custom programs. "ret" is the return value supposed

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -56,39 +56,4 @@ int is_valid_lxc_src_ipv4(struct iphdr *ip4 __maybe_unused)
 }
 #endif
 
-/**
- * ctx_redirect_to_proxy_hairpin redirects to the proxy by hairpining the
- * packet out the incoming interface
- */
-static __always_inline int
-ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port)
-{
-	union macaddr host_mac = HOST_IFINDEX_MAC;
-	union macaddr router_mac = NODE_MAC;
-	void *data_end = (void *) (long) ctx->data_end;
-	void *data = (void *) (long) ctx->data;
-	struct iphdr *ip4;
-	int ret;
-
-	ctx_store_meta(ctx, CB_PROXY_MAGIC,
-		       MARK_MAGIC_TO_PROXY | (proxy_port << 16));
-	bpf_barrier(); /* verifier workaround */
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
-
-	ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *) &router_mac, (__u8 *) &host_mac, ip4);
-	if (IS_ERR(ret))
-		return ret;
-
-	cilium_dbg(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port, 0);
-
-	/* Note that the actual __ctx_buff preparation for submitting the
-	 * packet to the proxy will occur in a subsequent program via
-	 * ctx_redirect_to_proxy_first().
-	 */
-
-	return redirect(HOST_IFINDEX, 0);
-}
-
 #endif /* __LIB_LXC_H_ */

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -220,15 +220,18 @@ func sliceToBe32(input []byte) uint32 {
 func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 	result := make(map[string]uint32)
 
-	if ipv6 := ep.IPv6Address(); ipv6 != nil {
-		// Corresponds to DEFINE_IPV6() in bpf/lib/utils.h
-		result["LXC_IP_1"] = sliceToBe32(ipv6[0:4])
-		result["LXC_IP_2"] = sliceToBe32(ipv6[4:8])
-		result["LXC_IP_3"] = sliceToBe32(ipv6[8:12])
-		result["LXC_IP_4"] = sliceToBe32(ipv6[12:16])
-	}
-	if ipv4 := ep.IPv4Address(); ipv4 != nil {
-		result["LXC_IPV4"] = byteorder.NetIPv4ToHost32(net.IP(ipv4))
+	// The following variables are not defined/used for host endpoint
+	if !ep.IsHost() {
+		if ipv6 := ep.IPv6Address(); ipv6 != nil {
+			// Corresponds to DEFINE_IPV6() in bpf/lib/utils.h
+			result["LXC_IP_1"] = sliceToBe32(ipv6[0:4])
+			result["LXC_IP_2"] = sliceToBe32(ipv6[4:8])
+			result["LXC_IP_3"] = sliceToBe32(ipv6[8:12])
+			result["LXC_IP_4"] = sliceToBe32(ipv6[12:16])
+		}
+		if ipv4 := ep.IPv4Address(); ipv4 != nil {
+			result["LXC_IPV4"] = byteorder.NetIPv4ToHost32(net.IP(ipv4))
+		}
 	}
 
 	mac := ep.GetNodeMAC()

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -520,6 +520,11 @@ func CreateHostEndpoint(owner regeneration.Owner, proxy EndpointProxy, allocator
 	ep.nodeMAC = mac
 	ep.DatapathConfiguration = NewDatapathConfiguration()
 
+	if option.Config.EnableHostFirewall {
+		ep.IPv4 = addressing.CiliumIPv4(node.GetIPv4())
+		ep.IPv6 = addressing.CiliumIPv6(node.GetIPv6())
+	}
+
 	ep.setState(StateWaitingForIdentity, "Endpoint creation")
 
 	return ep, nil

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -59,35 +59,37 @@ func (r Rule) Sanitize() error {
 		}
 	}
 
-	var hostPolicy bool
+	// var hostPolicy bool
 	if r.NodeSelector.LabelSelector != nil {
 		if err := r.NodeSelector.sanitize(); err != nil {
 			return err
 		}
-		hostPolicy = true
+		// hostPolicy = true
 	}
 
-	for i := range r.Ingress {
-		if err := r.Ingress[i].sanitize(); err != nil {
-			return err
-		}
-		if hostPolicy {
-			if len(countL7Rules(r.Ingress[i].ToPorts)) > 0 {
-				return fmt.Errorf("host policies do not support L7 rules yet")
+	/*
+		for i := range r.Ingress {
+			if err := r.Ingress[i].sanitize(); err != nil {
+				return err
+			}
+			if hostPolicy {
+				if len(countL7Rules(r.Ingress[i].ToPorts)) > 0 {
+					return fmt.Errorf("host policies do not support L7 rules yet")
+				}
 			}
 		}
-	}
 
-	for i := range r.Egress {
-		if err := r.Egress[i].sanitize(); err != nil {
-			return err
-		}
-		if hostPolicy {
-			if len(countL7Rules(r.Egress[i].ToPorts)) > 0 {
-				return fmt.Errorf("host policies do not support L7 rules yet")
+		for i := range r.Egress {
+			if err := r.Egress[i].sanitize(); err != nil {
+				return err
+			}
+			if hostPolicy {
+				if len(countL7Rules(r.Egress[i].ToPorts)) > 0 {
+					return fmt.Errorf("host policies do not support L7 rules yet")
+				}
 			}
 		}
-	}
+	*/
 
 	return nil
 }


### PR DESCRIPTION
* Changed validation function and allowed the host policies to have L7 rules. 
* Added changes in FQDN proxy to have egress proxy mark (0x0B00) on packets originating from proxy.
* Modified bpf datapath to do proxy redirection and skip policy enforcement for proxy traffic.

(Please refer individual commit messages for a detailed overview)